### PR TITLE
Update premove logic for counterattack

### DIFF
--- a/src/cli_chess/modules/premove/premove_model.py
+++ b/src/cli_chess/modules/premove/premove_model.py
@@ -66,7 +66,7 @@ class PremoveModel:
                 if isinstance(e, InvalidMoveError):
                     raise ValueError(f"Invalid premove: {move}")
                 elif isinstance(e, IllegalMoveError):
-                    raise ValueError(f"Illegal premove: {move}")
+                    return
                 elif isinstance(e, AmbiguousMoveError):
                     raise ValueError(f"Ambiguous premove: {move}")
                 else:


### PR DESCRIPTION
Updated the premove logic: it is now possible to premove to counterattack a piece

only after move:
<img width="660" height="386" alt="image" src="https://github.com/user-attachments/assets/97e1ae37-f304-49a8-a413-b0b66b92af6d" />

before premove: No errors

if move is legal:
just move