### PR TITLE
Highlight the selected squares as you type

### DIFF
--- a/src/cli_chess/core/game/game_presenter_base.py
+++ b/src/cli_chess/core/game/game_presenter_base.py
@@ -7,10 +7,14 @@ from cli_chess.modules.player_info import PlayerInfoPresenter
 from cli_chess.modules.clock import ClockPresenter
 from cli_chess.modules.premove import PremovePresenter
 from cli_chess.utils import log, AlertType, RequestSuccessfullySent, EventTopics
+from cli_chess.utils.config import game_config
+from cli_chess.utils.move_input_preview import analyze_move_input, longest_matching_san_prefix
 from abc import ABC, abstractmethod
+import chess
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from cli_chess.core.game import GameModelBase, PlayableGameModelBase
+    from prompt_toolkit.buffer import Buffer
 
 
 class GamePresenterBase(ABC):
@@ -55,6 +59,7 @@ class PlayableGamePresenterBase(GamePresenterBase, ABC):
         self.premove_presenter = PremovePresenter(model.premove_model)
         super().__init__(model)
         self.model = model
+        self._move_input_hint_text = ""
 
     @abstractmethod
     def _get_view(self) -> PlayableGameViewBase:
@@ -76,6 +81,77 @@ class PlayableGamePresenterBase(GamePresenterBase, ABC):
         if EventTopics.GAME_END in args:
             self._parse_and_present_game_over()
             self.premove_presenter.clear_premove()
+
+    def on_move_input_changed(self, text: str) -> None:
+        """Refresh live board hints and the move preview line while typing."""
+        self._refresh_move_input_preview(text)
+
+    def get_move_input_hint_text(self) -> str:
+        """Resolved SAN when input matches exactly one legal move (for the hint line)."""
+        return self._move_input_hint_text
+
+    def try_tab_complete_move_input(self, buffer: "Buffer") -> bool:
+        """Extend partial SAN to the longest common prefix of matching moves. Returns True if applied."""
+        if not game_config.get_boolean(game_config.Keys.LIVE_MOVE_INPUT_HIGHLIGHTS):
+            return False
+        if not game_config.get_boolean(game_config.Keys.LIVE_MOVE_INPUT_AUTOCOMPLETE):
+            return False
+        if self.model.board_model.is_game_over():
+            return False
+
+        current = buffer.text.strip()
+        if not current or current.lower().startswith("send"):
+            return False
+
+        board = self.model.board_model.board
+        next_prefix = longest_matching_san_prefix(board, current)
+        if not next_prefix or next_prefix == current:
+            return False
+
+        buffer.text = next_prefix
+        buffer.cursor_position = len(next_prefix)
+        return True
+
+    def _refresh_move_input_preview(self, text: str) -> None:
+        self._move_input_hint_text = ""
+        board_model = self.model.board_model
+
+        if not game_config.get_boolean(game_config.Keys.LIVE_MOVE_INPUT_HIGHLIGHTS):
+            board_model.clear_move_input_highlights()
+            return
+
+        if board_model.is_game_over():
+            board_model.clear_move_input_highlights()
+            return
+
+        stripped = text.strip()
+        if not stripped:
+            board_model.clear_move_input_highlights()
+            return
+
+        if stripped.lower().startswith("send"):
+            board_model.clear_move_input_highlights()
+            return
+
+        analysis = analyze_move_input(board_model.board, stripped)
+        if not analysis.from_squares:
+            board_model.clear_move_input_highlights()
+            return
+
+        show_targets = game_config.get_boolean(game_config.Keys.LIVE_MOVE_INPUT_SHOW_TARGETS)
+
+        if analysis.preview_move:
+            board_model.set_move_input_highlights(
+                set(),
+                set(),
+                analysis.preview_move,
+            )
+            self._move_input_hint_text = (
+                f"If you press Enter: {board_model.board.san(analysis.preview_move)}"
+            )
+        else:
+            to_sq = set(analysis.to_squares) if show_targets else set()
+            board_model.set_move_input_highlights(set(analysis.from_squares), to_sq, chess.Move.null())
 
     def user_input_received(self, inpt: str) -> None:
         """Respond to the users input. This input can either be the

--- a/src/cli_chess/core/game/game_view_base.py
+++ b/src/cli_chess/core/game/game_view_base.py
@@ -7,7 +7,7 @@ from prompt_toolkit.formatted_text import StyleAndTextTuples
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.filters import Condition
+from prompt_toolkit.filters import Condition, has_focus
 from abc import ABC, abstractmethod
 from typing import Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
@@ -93,6 +93,11 @@ class PlayableGameViewBase(GameViewBase, ABC):
         self.presenter = presenter
         self.premove_container = presenter.premove_presenter.view
         self.input_field_container = self._create_input_field_container()
+        self.input_field_container.buffer.on_text_changed.add_handler(self._on_move_input_buffer_changed)
+        self.move_input_hint_window = Window(
+            FormattedTextControl(lambda: self._move_input_hint_fragments()),
+            height=D(max=1),
+        )
         super().__init__(presenter)
 
     @abstractmethod
@@ -181,6 +186,11 @@ class PlayableGameViewBase(GameViewBase, ABC):
         def _(event):
             self.presenter.premove_presenter.clear_premove()
 
+        @bindings.add(Keys.Tab, filter=has_focus(self.input_field_container), eager=True)
+        def _(event):
+            if self.presenter.try_tab_complete_move_input(self.input_field_container.buffer):
+                event.app.invalidate()
+
         return merge_key_bindings([bindings, super().get_key_bindings()])
 
     def _create_input_field_container(self) -> TextArea:
@@ -199,3 +209,10 @@ class PlayableGameViewBase(GameViewBase, ABC):
         """Accept handler for the input field"""
         self.presenter.user_input_received(input.text)
         self.input_field_container.text = ''
+
+    def _on_move_input_buffer_changed(self, buffer: Buffer) -> None:
+        self.presenter.on_move_input_changed(buffer.text)
+
+    def _move_input_hint_fragments(self) -> StyleAndTextTuples:
+        text = self.presenter.get_move_input_hint_text()
+        return [("class:label.dim", text)] if text else []

--- a/src/cli_chess/core/game/offline_game/offline_game_view.py
+++ b/src/cli_chess/core/game/offline_game/offline_game_view.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from cli_chess.core.game import PlayableGameViewBase
-from prompt_toolkit.layout import Container, HSplit, VSplit, VerticalAlign
+from prompt_toolkit.layout import Container, HSplit, VSplit, VerticalAlign, D
 from prompt_toolkit.widgets import Box
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -25,7 +25,10 @@ class OfflineGameView(PlayableGameViewBase):
                         self.player_info_lower_container,
                     ]), padding=0, padding_top=1)
                 ]),
-                self.input_field_container,
+                HSplit([
+                    self.input_field_container,
+                    self.move_input_hint_window,
+                ], height=D(max=2, preferred=2)),
                 self.premove_container,
                 self.alert,
             ]),

--- a/src/cli_chess/core/game/online_game/online_game_view.py
+++ b/src/cli_chess/core/game/online_game/online_game_view.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from cli_chess.core.game import PlayableGameViewBase
-from prompt_toolkit.layout import Container, HSplit, VSplit, VerticalAlign
+from prompt_toolkit.layout import Container, HSplit, VSplit, VerticalAlign, D
 from prompt_toolkit.widgets import Box
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -29,7 +29,10 @@ class OnlineGameView(PlayableGameViewBase):
                     ]),
                     self.chat_container
                 ]),
-                self.input_field_container,
+                HSplit([
+                    self.input_field_container,
+                    self.move_input_hint_window,
+                ], height=D(max=2, preferred=2)),
                 self.premove_container,
                 self.alert,
             ]),

--- a/src/cli_chess/menus/program_settings_menu/program_settings_menu_model.py
+++ b/src/cli_chess/menus/program_settings_menu/program_settings_menu_model.py
@@ -19,6 +19,9 @@ class ProgramSettingsMenuModel(MultiValueMenuModel):
             MultiValueMenuOption(game_config.Keys.SHOW_MOVE_LIST_IN_UNICODE, "", self._get_available_game_config_options(game_config.Keys.SHOW_MOVE_LIST_IN_UNICODE), display_name="Show move list in unicode"),  # noqa: E501
             MultiValueMenuOption(game_config.Keys.SHOW_MATERIAL_DIFF_IN_UNICODE, "", self._get_available_game_config_options(game_config.Keys.SHOW_MATERIAL_DIFF_IN_UNICODE), display_name="Unicode material difference"),  # noqa: E501
             MultiValueMenuOption(game_config.Keys.PAD_UNICODE, "", self._get_available_game_config_options(game_config.Keys.PAD_UNICODE), display_name="Pad unicode (fix overlap)"),  # noqa: E501
+            MultiValueMenuOption(game_config.Keys.LIVE_MOVE_INPUT_HIGHLIGHTS, "", self._get_available_game_config_options(game_config.Keys.LIVE_MOVE_INPUT_HIGHLIGHTS), display_name="Live move input hints"),  # noqa: E501
+            MultiValueMenuOption(game_config.Keys.LIVE_MOVE_INPUT_SHOW_TARGETS, "", self._get_available_game_config_options(game_config.Keys.LIVE_MOVE_INPUT_SHOW_TARGETS), display_name="Show target squares"),  # noqa: E501
+            MultiValueMenuOption(game_config.Keys.LIVE_MOVE_INPUT_AUTOCOMPLETE, "", self._get_available_game_config_options(game_config.Keys.LIVE_MOVE_INPUT_AUTOCOMPLETE), display_name="Tab autocomplete"),  # noqa: E501
             MultiValueMenuOption(terminal_config.Keys.TERMINAL_COLOR_DEPTH, "", self._get_available_color_depth_options(), display_name="Terminal color depth"),  # noqa: E501
         ]
         return MenuCategory("Program Settings", menu_options)

--- a/src/cli_chess/modules/board/board_model.py
+++ b/src/cli_chess/modules/board/board_model.py
@@ -5,7 +5,7 @@ from cli_chess.utils.logging import log
 import chess
 import chess.variant
 from random import randint
-from typing import List, Optional
+from typing import List, Optional, Set
 
 
 class BoardModel:
@@ -16,6 +16,9 @@ class BoardModel:
         self.side_confirmed = side_confirmed  # flag to indicate if the users color is fully confirmed (e.g. online)
         self.highlight_move = chess.Move.null()
         self.premove_highlight = chess.Move.null()
+        self._move_input_from_squares: frozenset = frozenset()
+        self._move_input_to_squares: frozenset = frozenset()
+        self._move_input_preview_move: chess.Move = chess.Move.null()
         self._game_over_result: Optional[chess.Outcome] = None
         self._log_init_info()
 
@@ -54,6 +57,9 @@ class BoardModel:
             self.initial_fen = self.board.fen()
             self.set_board_orientation(chess.WHITE if variant.lower() == "racingkings" else orientation, notify=False)
             self.highlight_move = chess.Move.from_uci(uci_last_move) if uci_last_move else chess.Move.null()
+            self._move_input_from_squares = frozenset()
+            self._move_input_to_squares = frozenset()
+            self._move_input_preview_move = chess.Move.null()
             self._game_over_result = None
             self.side_confirmed = is_side_confirmed
 
@@ -69,6 +75,9 @@ class BoardModel:
         """
         self.board.reset()
         self.set_fen(self.initial_fen, notify=False)
+        self._move_input_from_squares = frozenset()
+        self._move_input_to_squares = frozenset()
+        self._move_input_preview_move = chess.Move.null()
         self._game_over_result = None
 
         if notify:
@@ -205,6 +214,45 @@ class BoardModel:
         """
         return self.highlight_move
 
+    def get_move_input_from_squares(self) -> frozenset:
+        """Squares to highlight as candidate moving pieces while typing a move."""
+        return self._move_input_from_squares
+
+    def get_move_input_to_squares(self) -> frozenset:
+        """Destination squares to highlight for in-progress move input (optional)."""
+        return self._move_input_to_squares
+
+    def get_move_input_preview_move(self) -> chess.Move:
+        """When input resolves to exactly one legal move, both ends are highlighted."""
+        return self._move_input_preview_move
+
+    def set_move_input_highlights(
+        self,
+        from_squares: Set[chess.Square],
+        to_squares: Set[chess.Square],
+        preview_move: chess.Move,
+        notify: bool = True,
+    ) -> None:
+        """Updates transient highlights driven by the move input field."""
+        self._move_input_from_squares = frozenset(from_squares)
+        self._move_input_to_squares = frozenset(to_squares)
+        self._move_input_preview_move = preview_move
+        if notify:
+            self._notify_board_model_updated()
+
+    def clear_move_input_highlights(self, notify: bool = True) -> None:
+        """Clears move-input-driven highlights."""
+        if (
+            self._move_input_from_squares
+            or self._move_input_to_squares
+            or bool(self._move_input_preview_move)
+        ):
+            self._move_input_from_squares = frozenset()
+            self._move_input_to_squares = frozenset()
+            self._move_input_preview_move = chess.Move.null()
+            if notify:
+                self._notify_board_model_updated()
+
     def set_board_orientation(self, color: chess.Color, notify=True) -> None:
         """Sets the board's orientation to the color passed in.
            If notify is false, a model update notification will not be sent.
@@ -314,6 +362,9 @@ class BoardModel:
             if fen:
                 self.set_fen(fen, notify=False)
                 self.highlight_move = chess.Move.from_uci(uci_last_move) if uci_last_move else chess.Move.null()
+                self._move_input_from_squares = frozenset()
+                self._move_input_to_squares = frozenset()
+                self._move_input_preview_move = chess.Move.null()
                 self._notify_board_model_updated()
         except Exception as e:
             log.error(f"Error caught setting board position: {e}")

--- a/src/cli_chess/modules/board/board_presenter.py
+++ b/src/cli_chess/modules/board/board_presenter.py
@@ -168,8 +168,21 @@ class BoardPresenter:
             except IndexError:
                 pass
 
-            if self.model.is_square_in_check(square):
-                square_color = "in-check"
+        live_hints = self.game_config_values.get(game_config.Keys.LIVE_MOVE_INPUT_HIGHLIGHTS, False)
+        if live_hints:
+            try:
+                preview = self.model.get_move_input_preview_move()
+                if bool(preview) and (square == preview.from_square or square == preview.to_square):
+                    square_color = "move-input-preview"
+                elif square in self.model.get_move_input_to_squares():
+                    square_color = "move-input-target"
+                elif square in self.model.get_move_input_from_squares():
+                    square_color = "move-input-piece"
+            except IndexError:
+                pass
+
+        if show_board_highlights and self.model.is_square_in_check(square):
+            square_color = "in-check"
 
         return square_color
 

--- a/src/cli_chess/tests/utils/test_move_input_preview.py
+++ b/src/cli_chess/tests/utils/test_move_input_preview.py
@@ -1,0 +1,50 @@
+import chess
+
+from cli_chess.utils.move_input_preview import (
+    analyze_move_input,
+    legal_moves_matching_san_prefix,
+    longest_matching_san_prefix,
+)
+
+
+def test_single_knight_prefix_identifies_one_square():
+    board = chess.Board("8/8/8/8/8/8/8/N3K2k w - - 0 1")
+    preview = analyze_move_input(board, "N")
+    assert preview.from_squares == frozenset([chess.A1])
+    assert preview.preview_move is None
+
+
+def test_unique_move_sets_preview():
+    board = chess.Board()
+    preview = analyze_move_input(board, "e4")
+    assert preview.preview_move is not None
+    assert preview.preview_move == chess.Move.from_uci("e2e4")
+
+
+def test_file_level_prefix_narrows_to_one_knight():
+    board = chess.Board()
+    nb_from = {m.from_square for m in legal_moves_matching_san_prefix(board, "Nc")}
+    nf_from = {m.from_square for m in legal_moves_matching_san_prefix(board, "Nf")}
+    assert nb_from == {chess.B1}
+    assert nf_from == {chess.G1}
+
+
+def test_castling_zero_for_letter_o():
+    board = chess.Board("r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1")
+    m_o = legal_moves_matching_san_prefix(board, "0-0")
+    m_O = legal_moves_matching_san_prefix(board, "O-O")
+    assert {m.uci() for m in m_o} == {m.uci() for m in m_O}
+
+
+def test_longest_common_prefix_completion():
+    board = chess.Board()
+    assert longest_matching_san_prefix(board, "N") == "N"
+    p = longest_matching_san_prefix(board, "e")
+    assert p.startswith("e")
+
+
+def test_no_match_returns_empty():
+    board = chess.Board()
+    preview = analyze_move_input(board, "Qzz")
+    assert preview.from_squares == frozenset()
+    assert longest_matching_san_prefix(board, "Qzz") == ""

--- a/src/cli_chess/utils/config.py
+++ b/src/cli_chess/utils/config.py
@@ -233,6 +233,9 @@ class GameConfig(SectionBase):
         SHOW_MOVE_LIST_IN_UNICODE = "show_move_list_in_unicode"
         SHOW_MATERIAL_DIFF_IN_UNICODE = "show_material_diff_in_unicode"
         PAD_UNICODE = "pad_unicode"
+        LIVE_MOVE_INPUT_HIGHLIGHTS = "live_move_input_highlights"
+        LIVE_MOVE_INPUT_SHOW_TARGETS = "live_move_input_show_targets"
+        LIVE_MOVE_INPUT_AUTOCOMPLETE = "live_move_input_autocomplete"
 
         @property
         def default_value(self):
@@ -245,6 +248,9 @@ class GameConfig(SectionBase):
                 self.SHOW_MOVE_LIST_IN_UNICODE: False,
                 self.SHOW_MATERIAL_DIFF_IN_UNICODE: True,
                 self.PAD_UNICODE: True,
+                self.LIVE_MOVE_INPUT_HIGHLIGHTS: False,
+                self.LIVE_MOVE_INPUT_SHOW_TARGETS: False,
+                self.LIVE_MOVE_INPUT_AUTOCOMPLETE: False,
             }
             return default_lookup[self]
 

--- a/src/cli_chess/utils/move_input_preview.py
+++ b/src/cli_chess/utils/move_input_preview.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import chess
+from dataclasses import dataclass
+from typing import FrozenSet, List, Optional, Set
+
+
+@dataclass(frozen=True)
+class MoveInputPreview:
+    """Derived from the current board and a partial SAN string."""
+
+    from_squares: FrozenSet[chess.Square]
+    to_squares: FrozenSet[chess.Square]
+    preview_move: Optional[chess.Move]
+
+
+def _prefix_variants(partial: str) -> List[str]:
+    """Allow castling to be typed with zero (0) instead of letter O."""
+    p = partial.strip()
+    if not p:
+        return []
+    alt = p.replace("0", "O")
+    return [p] if alt == p else [p, alt]
+
+
+def legal_moves_matching_san_prefix(board: chess.Board, partial: str) -> List[chess.Move]:
+    """All legal moves whose SAN begins with partial (case-insensitive)."""
+    variants = _prefix_variants(partial)
+    if not variants:
+        return []
+
+    matches: List[chess.Move] = []
+    for move in board.legal_moves:
+        san_lower = board.san(move).lower()
+        if any(san_lower.startswith(v.lower()) for v in variants):
+            matches.append(move)
+    return matches
+
+
+def analyze_move_input(board: chess.Board, partial: str) -> MoveInputPreview:
+    """Compute highlighted squares and a unique move, if the prefix resolves to one legal move."""
+    moves = legal_moves_matching_san_prefix(board, partial)
+    if not moves:
+        return MoveInputPreview(frozenset(), frozenset(), None)
+
+    from_squares: Set[chess.Square] = {m.from_square for m in moves}
+    to_squares: Set[chess.Square] = {m.to_square for m in moves}
+    preview: Optional[chess.Move] = moves[0] if len(moves) == 1 else None
+
+    return MoveInputPreview(frozenset(from_squares), frozenset(to_squares), preview)
+
+
+def longest_matching_san_prefix(board: chess.Board, partial: str) -> str:
+    """Longest common prefix of SAN strings for moves matching partial (for Tab completion)."""
+    moves = legal_moves_matching_san_prefix(board, partial)
+    if not moves:
+        return ""
+
+    sans = sorted({board.san(m) for m in moves})
+    first, last = sans[0], sans[-1]
+    max_len = min(len(first), len(last))
+    i = 0
+    while i < max_len and first[i].lower() == last[i].lower():
+        i += 1
+    return first[:i]

--- a/src/cli_chess/utils/styles.py
+++ b/src/cli_chess/utils/styles.py
@@ -22,6 +22,18 @@ default = {
     "pre-move.light-piece": f"fg:{light_piece_color}",
     "pre-move.dark-piece": f"fg:{dark_piece_color}",
 
+    "move-input-piece": "bg:steelblue",
+    "move-input-piece.light-piece": f"fg:{light_piece_color}",
+    "move-input-piece.dark-piece": f"fg:{dark_piece_color}",
+
+    "move-input-target": "bg:darkseagreen",
+    "move-input-target.light-piece": f"fg:{light_piece_color}",
+    "move-input-target.dark-piece": f"fg:{dark_piece_color}",
+
+    "move-input-preview": "bg:mediumturquoise",
+    "move-input-preview.light-piece": f"fg:{light_piece_color}",
+    "move-input-preview.dark-piece": f"fg:{dark_piece_color}",
+
     "in-check": "bg:red",
     "in-check.light-piece": f"fg:{light_piece_color}",
     "in-check.dark-piece": f"fg:{dark_piece_color}",


### PR DESCRIPTION
This is designed to complete issue #18. There are 3 new settings options to turn on highlighting for input pieces and target locations that are allowed by that given piece as the user types. There is also an option to press tab to autocomplete when there is only 1 viable movement option left, given the user's input.

Feel free to close this PR or edit it as much as you'd like!