### PR TITLE
Make the clock actually tick

### DIFF
--- a/src/cli_chess/core/game/game_metadata.py
+++ b/src/cli_chess/core/game/game_metadata.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from chess import Color, COLORS
+from time import monotonic
 from typing import Optional
 
 
@@ -19,6 +20,7 @@ class ClockMetadata:
     time: Optional[int] = None
     increment: Optional[int] = None
     ticking: bool = False
+    tick_started_at: Optional[float] = None
 
 
 @dataclass
@@ -42,9 +44,12 @@ class GameMetadata:
         if color is None:
             for c in COLORS:
                 self.clocks[c].ticking = False
+                self.clocks[c].tick_started_at = None
         else:
             self.clocks[color].ticking = True
+            self.clocks[color].tick_started_at = monotonic()
             self.clocks[not color].ticking = False
+            self.clocks[not color].tick_started_at = None
 
     def reset(self):
         self.__init__()

--- a/src/cli_chess/core/game/online_game/online_game_model.py
+++ b/src/cli_chess/core/game/online_game/online_game_model.py
@@ -259,6 +259,13 @@ class OnlineGameModel(PlayableGameModelBase):
             log.error(f"Error handling GameStateDispatcher event: {e}")
             raise
 
+    def _start_clock_on_side_to_move(self) -> None:
+        """Starts the clock of the side to move. Lichess does not charge either
+           player until they have both made their first move.
+        """
+        if len(self.board_model.get_move_stack()) >= 2:
+            self.game_metadata.set_clock_ticking(self.board_model.get_turn())
+
     def _update_game_metadata(self, *args, sender: Optional[EventSender] = None, data: Optional[Dict] = None, **kwargs) -> None:
         """Parses and saves the data of the game being played. Events come from senders
            in differing formats, which is why they are separated
@@ -292,7 +299,7 @@ class OnlineGameModel(PlayableGameModelBase):
 
             elif sender is EventSender.FROM_GSD:
                 if EventTopics.GAME_START in args:
-                    self.game_metadata.set_clock_ticking(self.board_model.get_turn())
+                    self._start_clock_on_side_to_move()
                     for color in COLOR_NAMES:
                         side_data = data.get(color, {})
                         color_as_bool = Color(COLOR_NAMES.index(color))
@@ -313,7 +320,7 @@ class OnlineGameModel(PlayableGameModelBase):
                 elif EventTopics.MOVE_MADE in args:
                     self.game_metadata.clocks[WHITE].time = data.get('wtime')
                     self.game_metadata.clocks[BLACK].time = data.get('btime')
-                    self.game_metadata.set_clock_ticking(self.board_model.get_turn()) if EventTopics.GAME_END not in args else None
+                    self._start_clock_on_side_to_move() if EventTopics.GAME_END not in args else None
 
             self._notify_game_model_updated(*args, **kwargs)
         except Exception as e:

--- a/src/cli_chess/modules/clock/clock_presenter.py
+++ b/src/cli_chess/modules/clock/clock_presenter.py
@@ -3,6 +3,7 @@ from cli_chess.modules.clock import ClockView
 from cli_chess.utils import EventTopics
 from chess import Color
 from datetime import datetime, timezone
+from time import monotonic
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -13,9 +14,8 @@ class ClockPresenter:
     def __init__(self, model: GameModelBase):
         self.model = model
 
-        orientation = self.model.board_model.get_board_orientation()
-        self.view_upper = ClockView(self, self.get_clock_display(not orientation))
-        self.view_lower = ClockView(self, self.get_clock_display(orientation))
+        self.view_upper = ClockView(self, lambda: self.get_clock_display(not self.model.board_model.get_board_orientation()))
+        self.view_lower = ClockView(self, lambda: self.get_clock_display(self.model.board_model.get_board_orientation()))
 
         self.model.e_game_model_updated.add_listener(self.update)
 
@@ -24,8 +24,8 @@ class ClockPresenter:
         if (EventTopics.GAME_START in args or EventTopics.GAME_END in args or
                 EventTopics.MOVE_MADE in args or EventTopics.BOARD_ORIENTATION_CHANGED in args):
             orientation = self.model.board_model.get_board_orientation()
-            self.view_upper.update(self.get_clock_display(not orientation), self.model.game_metadata.clocks[not orientation].ticking)
-            self.view_lower.update(self.get_clock_display(orientation), self.model.game_metadata.clocks[orientation].ticking)
+            self.view_upper.update(self.model.game_metadata.clocks[not orientation].ticking)
+            self.view_lower.update(self.model.game_metadata.clocks[orientation].ticking)
 
     def get_clock_display(self, color: Color) -> str:
         """Returns the formatted clock display for the color passed in"""
@@ -36,6 +36,12 @@ class ClockPresenter:
             return "--:--"
 
         if not isinstance(time, datetime):
+            if clock_data.ticking and clock_data.tick_started_at is not None:
+                elapsed = monotonic() - clock_data.tick_started_at
+                if clock_data.units == "ms":
+                    time = max(0.0, time - elapsed * 1000)
+                elif clock_data.units == "sec":
+                    time = max(0.0, time - elapsed)
             if clock_data.units == "ms":
                 time = datetime.fromtimestamp(time / 1000, timezone.utc)
             elif clock_data.units == "sec":

--- a/src/cli_chess/modules/clock/clock_presenter.py
+++ b/src/cli_chess/modules/clock/clock_presenter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from cli_chess.modules.clock import ClockView
 from cli_chess.utils import EventTopics
 from chess import Color
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from time import monotonic
 from typing import TYPE_CHECKING
 
@@ -36,15 +36,13 @@ class ClockPresenter:
             return "--:--"
 
         if not isinstance(time, datetime):
-            if clock_data.ticking and clock_data.tick_started_at is not None:
-                elapsed = monotonic() - clock_data.tick_started_at
-                if clock_data.units == "ms":
-                    time = max(0.0, time - elapsed * 1000)
-                elif clock_data.units == "sec":
-                    time = max(0.0, time - elapsed)
             if clock_data.units == "ms":
                 time = datetime.fromtimestamp(time / 1000, timezone.utc)
             elif clock_data.units == "sec":
                 time = datetime.fromtimestamp(time, timezone.utc)
+
+        if clock_data.ticking and clock_data.tick_started_at is not None:
+            elapsed = monotonic() - clock_data.tick_started_at
+            time = max(datetime.fromtimestamp(0, timezone.utc), time - timedelta(seconds=elapsed))
 
         return time.strftime("%M:%S") if not time.hour else time.strftime("%H:%M:%S")

--- a/src/cli_chess/modules/clock/clock_view.py
+++ b/src/cli_chess/modules/clock/clock_view.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 from prompt_toolkit.layout import Window, FormattedTextControl, WindowAlign, D
 from prompt_toolkit.widgets import Box
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 if TYPE_CHECKING:
     from cli_chess.modules.clock import ClockPresenter
 
 
 class ClockView:
-    def __init__(self, presenter: ClockPresenter, initial_time_str: str):
+    def __init__(self, presenter: ClockPresenter, get_time_str: Callable[[], str]):
         self.presenter = presenter
-        self.time_str = initial_time_str
-        self._clock_control = FormattedTextControl(text=lambda: self.time_str, style="class:clock")
+        self._clock_control = FormattedTextControl(text=get_time_str, style="class:clock")
         self._container = Box(Window(self._clock_control, align=WindowAlign.LEFT), padding=0, padding_right=1, height=D(max=1))
 
-    def update(self, time: str, is_ticking: bool) -> None:
-        """Updates the clock using the data passed in"""
-        self.time_str = time
+    def update(self, is_ticking: bool) -> None:
+        """Updates the clock style using the data passed in"""
         if is_ticking:
             self._clock_control.style = "class:clock.ticking"
         else:

--- a/src/cli_chess/tests/modules/clock/test_clock_presenter.py
+++ b/src/cli_chess/tests/modules/clock/test_clock_presenter.py
@@ -1,6 +1,7 @@
 from cli_chess.core.game import GameModelBase
 from cli_chess.modules.clock import ClockPresenter
 from chess import WHITE, BLACK
+from datetime import datetime, timezone
 import pytest
 
 
@@ -81,6 +82,25 @@ def test_game_end_freezes_both_clocks(model: GameModelBase, presenter: ClockPres
     fake_time[0] += 60.0
     assert presenter.get_clock_display(WHITE) == "01:00"
     assert presenter.get_clock_display(BLACK) == "00:30"
+
+
+def test_ticking_datetime_clock_decrements(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    # berserk converts the top level wtime/btime of a `gameState` event into datetimes
+    model.game_metadata.clocks[WHITE].units = "ms"
+    model.game_metadata.clocks[WHITE].time = datetime.fromtimestamp(60, timezone.utc)
+    model.game_metadata.set_clock_ticking(WHITE)
+
+    fake_time[0] += 5.0
+    assert presenter.get_clock_display(WHITE) == "00:55"
+
+
+def test_ticking_datetime_clock_floors_at_zero(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    model.game_metadata.clocks[WHITE].units = "ms"
+    model.game_metadata.clocks[WHITE].time = datetime.fromtimestamp(3, timezone.utc)
+    model.game_metadata.set_clock_ticking(WHITE)
+
+    fake_time[0] += 10.0
+    assert presenter.get_clock_display(WHITE) == "00:00"
 
 
 def test_hour_formatting_preserved(model: GameModelBase, presenter: ClockPresenter, fake_time: list):

--- a/src/cli_chess/tests/modules/clock/test_clock_presenter.py
+++ b/src/cli_chess/tests/modules/clock/test_clock_presenter.py
@@ -1,0 +1,89 @@
+from cli_chess.core.game import GameModelBase
+from cli_chess.modules.clock import ClockPresenter
+from chess import WHITE, BLACK
+import pytest
+
+
+@pytest.fixture
+def model():
+    return GameModelBase()
+
+
+@pytest.fixture
+def presenter(model: GameModelBase):
+    return ClockPresenter(model)
+
+
+@pytest.fixture
+def fake_time(monkeypatch):
+    now = [1000.0]
+    monkeypatch.setattr("cli_chess.core.game.game_metadata.monotonic", lambda: now[0])
+    monkeypatch.setattr("cli_chess.modules.clock.clock_presenter.monotonic", lambda: now[0])
+    return now
+
+
+def test_ticking_ms_clock_decrements(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    model.game_metadata.clocks[WHITE].units = "ms"
+    model.game_metadata.clocks[WHITE].time = 60000
+    model.game_metadata.set_clock_ticking(WHITE)
+    assert presenter.get_clock_display(WHITE) == "01:00"
+
+    fake_time[0] += 5.0
+    assert presenter.get_clock_display(WHITE) == "00:55"
+
+
+def test_non_ticking_clock_is_frozen(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    model.game_metadata.clocks[BLACK].units = "ms"
+    model.game_metadata.clocks[BLACK].time = 60000
+    model.game_metadata.set_clock_ticking(WHITE)
+
+    fake_time[0] += 30.0
+    assert presenter.get_clock_display(BLACK) == "01:00"
+
+
+def test_ticking_clock_floors_at_zero(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    model.game_metadata.clocks[WHITE].units = "ms"
+    model.game_metadata.clocks[WHITE].time = 3000
+    model.game_metadata.set_clock_ticking(WHITE)
+
+    fake_time[0] += 10.0
+    assert presenter.get_clock_display(WHITE) == "00:00"
+
+
+def test_missing_time_renders_placeholder(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    model.game_metadata.clocks[WHITE].time = None
+    assert presenter.get_clock_display(WHITE) == "--:--"
+
+    model.game_metadata.set_clock_ticking(WHITE)
+    fake_time[0] += 5.0
+    assert presenter.get_clock_display(WHITE) == "--:--"
+
+
+def test_ticking_sec_clock_decrements(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    model.game_metadata.clocks[WHITE].units = "sec"
+    model.game_metadata.clocks[WHITE].time = 90
+    model.game_metadata.set_clock_ticking(WHITE)
+
+    fake_time[0] += 30.0
+    assert presenter.get_clock_display(WHITE) == "01:00"
+
+
+def test_game_end_freezes_both_clocks(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    model.game_metadata.clocks[WHITE].units = "ms"
+    model.game_metadata.clocks[WHITE].time = 60000
+    model.game_metadata.clocks[BLACK].units = "ms"
+    model.game_metadata.clocks[BLACK].time = 30000
+    model.game_metadata.set_clock_ticking(WHITE)
+
+    fake_time[0] += 5.0
+    model.game_metadata.set_clock_ticking(None)
+
+    fake_time[0] += 60.0
+    assert presenter.get_clock_display(WHITE) == "01:00"
+    assert presenter.get_clock_display(BLACK) == "00:30"
+
+
+def test_hour_formatting_preserved(model: GameModelBase, presenter: ClockPresenter, fake_time: list):
+    model.game_metadata.clocks[WHITE].units = "ms"
+    model.game_metadata.clocks[WHITE].time = 3_660_000
+    assert presenter.get_clock_display(WHITE) == "01:01:00"


### PR DESCRIPTION
Previously the clock only updated when a move was made. Now the clock actively counts down so you're never guessing. Once a move is made the clock snaps back to the server's time if it's off.

Closes #11 